### PR TITLE
feat(client): add theme toggle and search

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
         "chart.js": "^4.5.0",
         "react": "^19.1.0",
@@ -1186,6 +1187,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.2.0.tgz",
+      "integrity": "sha512-gRCspp3pfjHQyTmSOmYw7kUQTd9Udpdan4R8EnZvqPeoAtHnPzkvjBrBqzKaoAbbBp5bGF7BcD18zZJh4nwu0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.2.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
     "chart.js": "^4.5.0",
     "react": "^19.1.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,23 +2,30 @@ import { useState, useEffect, useCallback } from 'react'
 import { Line } from 'react-chartjs-2'
 import 'chart.js/auto'
 import {
-  Container,
-  Typography,
+  AppBar,
   Box,
-  Paper,
-  Tabs,
-  Tab,
+  Container,
+  IconButton,
+  InputAdornment,
   List,
   ListItemButton,
   ListItemText,
+  Paper,
+  Tab,
+  Tabs,
+  TextField,
+  Toolbar,
+  Typography,
 } from '@mui/material'
+import { Brightness4, Brightness7, Search } from '@mui/icons-material'
 import './App.css'
 
-function App() {
+function App({ mode, setMode }) {
   const [tab, setTab] = useState(0)
   const [items, setItems] = useState([])
   const [selectedItem, setSelectedItem] = useState(null)
   const [history, setHistory] = useState([])
+  const [search, setSearch] = useState('')
 
   useEffect(() => {
     fetch('http://localhost:3001/api/items')
@@ -42,6 +49,10 @@ function App() {
       fetchHistory(selectedItem)
     }
   }, [selectedItem, fetchHistory])
+
+  const filteredItems = items.filter((it) =>
+    it.id.toLowerCase().includes(search.toLowerCase()),
+  )
 
   const variations = [...items]
     .map((it) => ({
@@ -71,67 +82,93 @@ function App() {
   }
 
   return (
-    <Container className="App" maxWidth="lg" sx={{ py: 4 }}>
-      <Typography variant="h4" component="h1" gutterBottom align="center">
-        Bazaar Tracker
-      </Typography>
-      <Tabs value={tab} onChange={(e, v) => setTab(v)} centered>
-        <Tab label="Top Variation" />
-        <Tab label="All Items" />
-      </Tabs>
-      {tab === 0 && (
-        <Box mt={2}>
-          <List>
-            {variations.map((v) => (
-              <ListItemButton
-                key={v.id}
-                onClick={() => {
-                  setSelectedItem(v.id)
-                  setTab(1)
-                }}
-              >
-                <ListItemText
-                  primary={v.id}
-                  secondary={`Variation: ${v.variation.toFixed(2)}`}
-                />
-              </ListItemButton>
-            ))}
-          </List>
-        </Box>
-      )}
-      {tab === 1 && (
-        <Box mt={2} display="flex" gap={2}>
-          <Box width="30%" maxHeight={400} sx={{ overflowY: 'auto' }}>
+    <>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Bazaar Tracker
+          </Typography>
+          <IconButton
+            color="inherit"
+            onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
+          >
+            {mode === 'light' ? <Brightness4 /> : <Brightness7 />}
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <Container className="App" maxWidth="lg" sx={{ py: 4 }}>
+        <Tabs value={tab} onChange={(e, v) => setTab(v)} centered>
+          <Tab label="Top Variation" />
+          <Tab label="All Items" />
+        </Tabs>
+        {tab === 0 && (
+          <Box mt={2}>
             <List>
-              {items.map((it) => (
+              {variations.map((v) => (
                 <ListItemButton
-                  key={it.id}
-                  selected={it.id === selectedItem}
-                  onClick={() => setSelectedItem(it.id)}
+                  key={v.id}
+                  onClick={() => {
+                    setSelectedItem(v.id)
+                    setTab(1)
+                  }}
                 >
                   <ListItemText
-                    primary={it.id}
-                    secondary={`Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`}
+                    primary={v.id}
+                    secondary={`Variation: ${v.variation.toFixed(2)}`}
                   />
                 </ListItemButton>
               ))}
             </List>
           </Box>
-          <Box flexGrow={1}>
-            {selectedItem && (
-              <Paper sx={{ p: 2 }}>
-                <Typography variant="h6" align="center" gutterBottom>
-                  {selectedItem}
-                </Typography>
-                <Box height={400}>
-                  <Line data={chartData} />
-                </Box>
-              </Paper>
-            )}
+        )}
+        {tab === 1 && (
+          <Box mt={2} display="flex" gap={2}>
+            <Box width="30%" maxHeight={400} sx={{ overflowY: 'auto' }}>
+              <TextField
+                fullWidth
+                size="small"
+                placeholder="Search items..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <Search />
+                    </InputAdornment>
+                  ),
+                }}
+              />
+              <List>
+                {filteredItems.map((it) => (
+                  <ListItemButton
+                    key={it.id}
+                    selected={it.id === selectedItem}
+                    onClick={() => setSelectedItem(it.id)}
+                  >
+                    <ListItemText
+                      primary={it.id}
+                      secondary={`Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`}
+                    />
+                  </ListItemButton>
+                ))}
+              </List>
+            </Box>
+            <Box flexGrow={1}>
+              {selectedItem && (
+                <Paper sx={{ p: 2 }}>
+                  <Typography variant="h6" align="center" gutterBottom>
+                    {selectedItem}
+                  </Typography>
+                  <Box height={400}>
+                    <Line data={chartData} />
+                  </Box>
+                </Paper>
+              )}
+            </Box>
           </Box>
-        </Box>
-      )}
-    </Container>
+        )}
+      </Container>
+    </>
   )
 }
 

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,27 +1,36 @@
-import { StrictMode } from 'react'
+import { StrictMode, useMemo, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ThemeProvider, CssBaseline, createTheme } from '@mui/material'
 import './index.css'
 import App from './App.jsx'
 
-const theme = createTheme({
-  palette: {
-    mode: 'dark',
-    primary: {
-      main: '#1976d2',
-    },
-    background: {
-      default: '#121212',
-      paper: '#1e1e1e',
-    },
-  },
-})
+// eslint-disable-next-line react-refresh/only-export-components
+const Root = () => {
+  const [mode, setMode] = useState('light')
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode,
+          primary: {
+            main: '#1976d2',
+          },
+        },
+      }),
+    [mode],
+  )
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App mode={mode} setMode={setMode} />
+    </ThemeProvider>
+  )
+}
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <App />
-    </ThemeProvider>
+    <Root />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add AppBar with light/dark toggle for more professional UI
- filter item list via search field
- manage theme mode at root and include icons package

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891588951b8832d9c23ab2981be069f