### PR TITLE
feat: add custom theme

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -15,6 +15,27 @@ const theme = createTheme({
       paper: '#1e1e1e',
     },
   },
+  typography: {
+    fontFamily: 'Roboto, sans-serif',
+    h1: {
+      fontSize: '2rem',
+      fontWeight: 500,
+    },
+    body1: {
+      fontSize: '1rem',
+    },
+  },
+  spacing: 4,
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          textTransform: 'none',
+        },
+      },
+    },
+  },
 })
 
 createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- define dark theme with custom typography, spacing, and button override
- apply theme through ThemeProvider for global styles

## Testing
- `npm test` (fails: no test specified)
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689159c813a4832d80f4d1654e28f716