### PR TITLE
Refactor client UI into modular components and hooks

### DIFF
--- a/client/src/components/HistoryChart.jsx
+++ b/client/src/components/HistoryChart.jsx
@@ -1,0 +1,38 @@
+import { Line } from 'react-chartjs-2'
+import 'chart.js/auto'
+import { Paper, Typography, Box } from '@mui/material'
+
+function HistoryChart({ history, selectedItem }) {
+  if (!selectedItem) return null
+
+  const chartData = {
+    labels: history.map((h) => new Date(h.time).toLocaleTimeString()),
+    datasets: [
+      {
+        label: 'Buy Price',
+        data: history.map((h) => h.buyPrice),
+        borderColor: 'rgb(75,192,192)',
+        fill: false,
+      },
+      {
+        label: 'Sell Price',
+        data: history.map((h) => h.sellPrice),
+        borderColor: 'rgb(192,75,75)',
+        fill: false,
+      },
+    ],
+  }
+
+  return (
+    <Paper sx={{ p: 2 }}>
+      <Typography variant="h6" align="center" gutterBottom>
+        {selectedItem}
+      </Typography>
+      <Box height={400}>
+        <Line data={chartData} />
+      </Box>
+    </Paper>
+  )
+}
+
+export default HistoryChart

--- a/client/src/components/ItemList.jsx
+++ b/client/src/components/ItemList.jsx
@@ -1,0 +1,22 @@
+import { List, ListItemButton, ListItemText } from '@mui/material'
+
+function ItemList({ items, selectedItem, onSelect }) {
+  return (
+    <List>
+      {items.map((it) => (
+        <ListItemButton
+          key={it.id}
+          selected={it.id === selectedItem}
+          onClick={() => onSelect(it.id)}
+        >
+          <ListItemText
+            primary={it.id}
+            secondary={`Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`}
+          />
+        </ListItemButton>
+      ))}
+    </List>
+  )
+}
+
+export default ItemList

--- a/client/src/components/VariationList.jsx
+++ b/client/src/components/VariationList.jsx
@@ -1,0 +1,27 @@
+import { List, ListItemButton, ListItemText } from '@mui/material'
+
+function VariationList({ items, onSelect }) {
+  const variations = [...items]
+    .map((it) => ({
+      id: it.id,
+      variation:
+        (it.quick_status.sellPrice || 0) - (it.quick_status.buyPrice || 0),
+    }))
+    .sort((a, b) => b.variation - a.variation)
+    .slice(0, 10)
+
+  return (
+    <List>
+      {variations.map((v) => (
+        <ListItemButton key={v.id} onClick={() => onSelect(v.id)}>
+          <ListItemText
+            primary={v.id}
+            secondary={`Variation: ${v.variation.toFixed(2)}`}
+          />
+        </ListItemButton>
+      ))}
+    </List>
+  )
+}
+
+export default VariationList

--- a/client/src/hooks/useHistory.js
+++ b/client/src/hooks/useHistory.js
@@ -1,0 +1,21 @@
+import { useState, useEffect, useCallback } from 'react'
+
+function useHistory(selectedItem) {
+  const [history, setHistory] = useState([])
+
+  const fetchHistory = useCallback(async (id) => {
+    const res = await fetch(`http://localhost:3001/api/items/${id}`)
+    const json = await res.json()
+    setHistory(json)
+  }, [])
+
+  useEffect(() => {
+    if (selectedItem) {
+      fetchHistory(selectedItem)
+    }
+  }, [selectedItem, fetchHistory])
+
+  return { history, fetchHistory }
+}
+
+export default useHistory


### PR DESCRIPTION
## Summary
- Extract top-variation display into `VariationList` component and item selection UI into `ItemList`.
- Move chart rendering into `HistoryChart` and introduce reusable `useHistory` hook.
- Simplify `App.jsx` to compose new components and hook for cleaner logic.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689159d32bd0832d937eba745d6e9528