### PR TITLE
feat: extract history chart component

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,4 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Line } from 'react-chartjs-2'
-import 'chart.js/auto'
 import {
   Container,
   Typography,
@@ -12,6 +10,7 @@ import {
   ListItemButton,
   ListItemText,
 } from '@mui/material'
+import HistoryChart from './components/HistoryChart'
 import './App.css'
 
 function App() {
@@ -51,24 +50,6 @@ function App() {
     }))
     .sort((a, b) => b.variation - a.variation)
     .slice(0, 10)
-
-  const chartData = {
-    labels: history.map((h) => new Date(h.time).toLocaleTimeString()),
-    datasets: [
-      {
-        label: 'Buy Price',
-        data: history.map((h) => h.buyPrice),
-        borderColor: 'rgb(75,192,192)',
-        fill: false,
-      },
-      {
-        label: 'Sell Price',
-        data: history.map((h) => h.sellPrice),
-        borderColor: 'rgb(192,75,75)',
-        fill: false,
-      },
-    ],
-  }
 
   return (
     <Container className="App" maxWidth="lg" sx={{ py: 4 }}>
@@ -124,7 +105,7 @@ function App() {
                   {selectedItem}
                 </Typography>
                 <Box height={400}>
-                  <Line data={chartData} />
+                  <HistoryChart history={history} />
                 </Box>
               </Paper>
             )}

--- a/client/src/components/HistoryChart.jsx
+++ b/client/src/components/HistoryChart.jsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react'
+import { Line } from 'react-chartjs-2'
+import 'chart.js/auto'
+import { useTheme } from '@mui/material/styles'
+
+function HistoryChart({ history }) {
+  const theme = useTheme()
+
+  const data = useMemo(
+    () => ({
+      labels: history.map((h) => new Date(h.time).toLocaleTimeString()),
+      datasets: [
+        {
+          label: 'Buy Price',
+          data: history.map((h) => h.buyPrice),
+          borderColor: theme.palette.primary.main,
+          backgroundColor: theme.palette.primary.light,
+          fill: false,
+        },
+        {
+          label: 'Sell Price',
+          data: history.map((h) => h.sellPrice),
+          borderColor: theme.palette.error.main,
+          backgroundColor: theme.palette.error.light,
+          fill: false,
+        },
+      ],
+    }),
+    [history, theme]
+  )
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        tooltip: {
+          mode: 'index',
+          intersect: false,
+        },
+        legend: {
+          labels: {
+            color: theme.palette.text.primary,
+            font: {
+              family: theme.typography.fontFamily,
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          ticks: {
+            color: theme.palette.text.secondary,
+            font: {
+              family: theme.typography.fontFamily,
+            },
+          },
+          grid: {
+            color: theme.palette.divider,
+          },
+        },
+        y: {
+          ticks: {
+            color: theme.palette.text.secondary,
+            font: {
+              family: theme.typography.fontFamily,
+            },
+          },
+          grid: {
+            color: theme.palette.divider,
+          },
+        },
+      },
+    }),
+    [theme]
+  )
+
+  return <Line data={data} options={options} />
+}
+
+export default HistoryChart
+


### PR DESCRIPTION
## Summary
- create `HistoryChart` component with centralized chart options for fonts, colors, tooltips and responsive behavior
- color datasets via MUI theme and enhance gridline visibility
- delegate price history rendering in `App` to new `HistoryChart`

## Testing
- `npm --prefix client run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689159d7ce18832db2a675db8db1996f