### PR TITLE
feat: show neural prediction in item chart

### DIFF
--- a/client/src/components/ItemChart.jsx
+++ b/client/src/components/ItemChart.jsx
@@ -1,6 +1,7 @@
 import { Paper, Typography, Box } from '@mui/material'
 import { Line } from 'react-chartjs-2'
 import 'chart.js/auto'
+import NeuralPrediction from '../NeuralPrediction'
 
 function ItemChart({ selectedItem, history }) {
   if (!selectedItem) return null
@@ -30,6 +31,9 @@ function ItemChart({ selectedItem, history }) {
       </Typography>
       <Box height={400}>
         <Line data={chartData} />
+      </Box>
+      <Box mt={2}>
+        <NeuralPrediction itemId={selectedItem} />
       </Box>
     </Paper>
   )


### PR DESCRIPTION
## Summary
- import NeuralPrediction into ItemChart and render beneath price chart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689163964200832d8bb30f95456d7c7f