### PR TITLE
Add tests for client components and server routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # start-from-scratch-codex
+
+## Running Tests
+
+This project contains both server (Jest) and client (Vitest) test suites.
+Run all tests with:
+
+```bash
+npm test
+```
+
+This command executes server tests followed by client tests.

--- a/client/src/components/ItemChart.test.jsx
+++ b/client/src/components/ItemChart.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import ItemChart from './ItemChart';
+import { vi } from 'vitest';
+
+vi.mock('react-chartjs-2', () => ({
+  Line: () => <div data-testid="chart" />, // simple mock
+}));
+
+vi.mock('chart.js/auto', () => ({}));
+
+test('renders nothing when no item selected', () => {
+  const { container } = render(<ItemChart selectedItem="" history={[]} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+test('renders chart for selected item', () => {
+  const history = [
+    { time: 0, buyPrice: 1, sellPrice: 2 },
+    { time: 1, buyPrice: 3, sellPrice: 4 },
+  ];
+  render(<ItemChart selectedItem="TEST" history={history} />);
+  expect(screen.getByText('TEST')).toBeInTheDocument();
+  expect(screen.getByTestId('chart')).toBeInTheDocument();
+});
+

--- a/client/src/components/ItemList.test.jsx
+++ b/client/src/components/ItemList.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ItemList from './ItemList';
+import { vi } from 'vitest';
+
+test('renders items and handles selection', () => {
+  const items = [
+    { id: 'ITEM1' },
+    { id: 'ITEM2' },
+  ];
+  const onItemSelect = vi.fn();
+  const getSecondary = (item) => `secondary ${item.id}`;
+
+  render(
+    <ItemList
+      items={items}
+      onItemSelect={onItemSelect}
+      selectedItem="ITEM1"
+      getSecondary={getSecondary}
+    />
+  );
+
+  expect(screen.getByText('ITEM1')).toBeInTheDocument();
+  expect(screen.getByText('secondary ITEM1')).toBeInTheDocument();
+
+  const first = screen.getByRole('button', { name: /ITEM1/ });
+  expect(first).toHaveClass('Mui-selected');
+
+  fireEvent.click(screen.getByText('ITEM2'));
+  expect(onItemSelect).toHaveBeenCalledWith('ITEM2');
+});
+

--- a/server/__tests__/route.test.js
+++ b/server/__tests__/route.test.js
@@ -1,8 +1,50 @@
 const request = require('supertest');
 const { app, bazaarData } = require('../index');
 
+beforeEach(() => {
+  for (const key in bazaarData) {
+    delete bazaarData[key];
+  }
+});
+
+describe('GET /api/items', () => {
+  test('returns list of items', async () => {
+    bazaarData.TEST = {
+      history: [],
+      product: { quick_status: { buyPrice: 100 } },
+    };
+    const res = await request(app).get('/api/items');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: 'TEST', quick_status: { buyPrice: 100 } },
+    ]);
+  });
+
+  test('returns empty list when no items', async () => {
+    const res = await request(app).get('/api/items');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});
+
+describe('GET /api/items/:id', () => {
+  test('returns item history', async () => {
+    const history = [{ time: 1, buyPrice: 10 }];
+    bazaarData.TEST = { history };
+    const res = await request(app).get('/api/items/TEST');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(history);
+  });
+
+  test('returns empty array for unknown item', async () => {
+    const res = await request(app).get('/api/items/UNKNOWN');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});
+
 describe('GET /api/items/:id/neural-prediction', () => {
-  beforeEach(() => {
+  test('returns predicted price', async () => {
     bazaarData.TEST = {
       history: [
         { time: 1, buyPrice: 10 },
@@ -11,11 +53,21 @@ describe('GET /api/items/:id/neural-prediction', () => {
         { time: 4, buyPrice: 40 },
       ],
     };
-  });
-
-  test('returns predicted price', async () => {
     const res = await request(app).get('/api/items/TEST/neural-prediction');
     expect(res.status).toBe(200);
     expect(res.body.predictedPrice).toBeCloseTo(27);
   });
+
+  test('handles insufficient data', async () => {
+    bazaarData.FEW = {
+      history: [
+        { time: 1, buyPrice: 10 },
+        { time: 2, buyPrice: 20 },
+      ],
+    };
+    const res = await request(app).get('/api/items/FEW/neural-prediction');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({});
+  });
 });
+


### PR DESCRIPTION
## Summary
- add testing-library coverage for ItemList and ItemChart
- extend server route tests for /api/items and /api/items/:id including error cases
- document unified `npm test` command in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891639bad84832d9965319f2f7ca88c