### PR TITLE
Handle client fetch errors

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,22 +9,46 @@ function App() {
   const [items, setItems] = useState([])
   const [selectedItem, setSelectedItem] = useState(null)
   const [history, setHistory] = useState([])
+  const [itemsLoading, setItemsLoading] = useState(false)
+  const [itemsError, setItemsError] = useState(null)
+  const [historyLoading, setHistoryLoading] = useState(false)
+  const [historyError, setHistoryError] = useState(null)
 
   useEffect(() => {
-    fetch('http://localhost:3001/api/items')
-      .then((res) => res.json())
-      .then((data) => {
+    const fetchItems = async () => {
+      setItemsLoading(true)
+      setItemsError(null)
+      try {
+        const res = await fetch('http://localhost:3001/api/items')
+        if (!res.ok) throw new Error('Network response was not ok')
+        const data = await res.json()
         setItems(data)
         if (data.length > 0) {
           setSelectedItem(data[0].id)
         }
-      })
+      } catch (err) {
+        setItemsError(err.message)
+      } finally {
+        setItemsLoading(false)
+      }
+    }
+    fetchItems()
   }, [])
 
   const fetchHistory = useCallback(async (id) => {
-    const res = await fetch(`http://localhost:3001/api/items/${id}`)
-    const json = await res.json()
-    setHistory(json)
+    setHistoryLoading(true)
+    setHistoryError(null)
+    try {
+      const res = await fetch(`http://localhost:3001/api/items/${id}`)
+      if (!res.ok) throw new Error('Network response was not ok')
+      const json = await res.json()
+      setHistory(json)
+    } catch (err) {
+      setHistoryError(err.message)
+      setHistory([])
+    } finally {
+      setHistoryLoading(false)
+    }
   }, [])
 
   useEffect(() => {
@@ -47,38 +71,58 @@ function App() {
       <Typography variant="h4" component="h1" gutterBottom align="center">
         Bazaar Tracker
       </Typography>
-      <Tabs value={tab} onChange={(e, v) => setTab(v)} centered>
-        <Tab label="Top Variation" />
-        <Tab label="All Items" />
-      </Tabs>
-      {tab === 0 && (
-        <Box mt={2}>
-          <ItemList
-            items={variations}
-            onItemSelect={(id) => {
-              setSelectedItem(id)
-              setTab(1)
-            }}
-            getSecondary={(v) => `Variation: ${v.variation.toFixed(2)}`}
-          />
-        </Box>
+      {itemsLoading && (
+        <Typography align="center">Loading items...</Typography>
       )}
-      {tab === 1 && (
-        <Box mt={2} display="flex" gap={2}>
-          <Box width="30%" maxHeight={400} sx={{ overflowY: 'auto' }}>
-            <ItemList
-              items={items}
-              selectedItem={selectedItem}
-              onItemSelect={setSelectedItem}
-              getSecondary={(it) =>
-                `Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`
-              }
-            />
-          </Box>
-          <Box flexGrow={1}>
-            <ItemChart selectedItem={selectedItem} history={history} />
-          </Box>
-        </Box>
+      {itemsError && (
+        <Typography align="center" color="error">
+          Error loading items: {itemsError}
+        </Typography>
+      )}
+      {!itemsLoading && !itemsError && (
+        <>
+          <Tabs value={tab} onChange={(e, v) => setTab(v)} centered>
+            <Tab label="Top Variation" />
+            <Tab label="All Items" />
+          </Tabs>
+          {tab === 0 && (
+            <Box mt={2}>
+              <ItemList
+                items={variations}
+                onItemSelect={(id) => {
+                  setSelectedItem(id)
+                  setTab(1)
+                }}
+                getSecondary={(v) => `Variation: ${v.variation.toFixed(2)}`}
+              />
+            </Box>
+          )}
+          {tab === 1 && (
+            <Box mt={2} display="flex" gap={2}>
+              <Box width="30%" maxHeight={400} sx={{ overflowY: 'auto' }}>
+                <ItemList
+                  items={items}
+                  selectedItem={selectedItem}
+                  onItemSelect={setSelectedItem}
+                  getSecondary={(it) =>
+                    `Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`
+                  }
+                />
+              </Box>
+              <Box flexGrow={1}>
+                {historyError ? (
+                  <Typography color="error">
+                    Error loading history: {historyError}
+                  </Typography>
+                ) : historyLoading ? (
+                  <Typography>Loading history...</Typography>
+                ) : (
+                  <ItemChart selectedItem={selectedItem} history={history} />
+                )}
+              </Box>
+            </Box>
+          )}
+        </>
       )}
     </Container>
   )

--- a/client/src/NeuralPrediction.jsx
+++ b/client/src/NeuralPrediction.jsx
@@ -2,21 +2,41 @@ import { useEffect, useState } from 'react';
 
 export default function NeuralPrediction({ itemId }) {
   const [prediction, setPrediction] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     let mounted = true;
-    fetch(`/api/items/${itemId}/neural-prediction`)
-      .then((res) => res.json())
-      .then((data) => {
+    const fetchPrediction = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/items/${itemId}/neural-prediction`);
+        if (!res.ok) throw new Error('Network response was not ok');
+        const data = await res.json();
         if (mounted) setPrediction(data.predictedPrice);
-      });
+      } catch (err) {
+        if (mounted) setError(err.message);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+    fetchPrediction();
     return () => {
       mounted = false;
     };
   }, [itemId]);
 
-  if (prediction == null) {
+  if (loading) {
     return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (prediction == null) {
+    return <div>No prediction available</div>;
   }
 
   return <div>Prediction: {prediction.toFixed(2)}</div>;

--- a/client/src/NeuralPrediction.test.jsx
+++ b/client/src/NeuralPrediction.test.jsx
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 
 test('fetches and displays prediction', async () => {
   const fakeFetch = vi.fn().mockResolvedValue({
+    ok: true,
     json: () => Promise.resolve({ predictedPrice: 99 })
   });
   global.fetch = fakeFetch;


### PR DESCRIPTION
## Summary
- add loading and error state handling for item and history requests
- wrap neural prediction fetch in try/catch with error display
- update neural prediction test to mock a successful response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891638f318c832d915c80ec82e18d8c