### PR TITLE
Make API URL configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+VITE_API_URL=http://localhost:3001
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # start-from-scratch-codex
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values as needed. The client recognizes the following variable:
+
+```
+VITE_API_URL=http://localhost:3001
+```
+
+`VITE_API_URL` sets the base URL for API requests from the client. If it is not defined, the client will use the same origin as the loaded page.
+
+

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,8 @@ import './App.css'
 import ItemList from './components/ItemList'
 import ItemChart from './components/ItemChart'
 
+const API_URL = import.meta.env.VITE_API_URL || ''
+
 function App() {
   const [tab, setTab] = useState(0)
   const [items, setItems] = useState([])
@@ -11,7 +13,7 @@ function App() {
   const [history, setHistory] = useState([])
 
   useEffect(() => {
-    fetch('http://localhost:3001/api/items')
+    fetch(`${API_URL}/api/items`)
       .then((res) => res.json())
       .then((data) => {
         setItems(data)
@@ -22,7 +24,7 @@ function App() {
   }, [])
 
   const fetchHistory = useCallback(async (id) => {
-    const res = await fetch(`http://localhost:3001/api/items/${id}`)
+    const res = await fetch(`${API_URL}/api/items/${id}`)
     const json = await res.json()
     setHistory(json)
   }, [])
@@ -85,3 +87,4 @@ function App() {
 }
 
 export default App
+


### PR DESCRIPTION
## Summary
- use `VITE_API_URL` env var in the client to allow overriding API base URL
- document API URL env var and provide sample `.env.example`

## Testing
- `npm test`
- `npm run lint --prefix client` *(fails: 'test' and 'expect' not defined in client/src/NeuralPrediction.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_6891638c5f2c832d89ab6296a6d410d9