### PR TITLE
Implement timeframe-based price variations

### DIFF
--- a/server/__tests__/variations.test.js
+++ b/server/__tests__/variations.test.js
@@ -1,0 +1,35 @@
+const request = require('supertest');
+const { app, bazaarData } = require('../index');
+
+describe('GET /api/variations', () => {
+  beforeEach(() => {
+    const now = Date.now();
+    bazaarData.A = {
+      history: [
+        { time: now - 60 * 1000, buyPrice: 10 },
+        { time: now, buyPrice: 15 },
+      ],
+    };
+    bazaarData.B = {
+      history: [
+        { time: now - 60 * 1000, buyPrice: 10 },
+        { time: now, buyPrice: 5 },
+      ],
+    };
+  });
+
+  afterEach(() => {
+    delete bazaarData.A;
+    delete bazaarData.B;
+  });
+
+  test('calculates variations for timeframe', async () => {
+    const res = await request(app).get('/api/variations?timeframe=1m');
+    expect(res.status).toBe(200);
+    const body = res.body;
+    const itemA = body.find((v) => v.id === 'A');
+    const itemB = body.find((v) => v.id === 'B');
+    expect(itemA.variation).toBeCloseTo(5);
+    expect(itemB.variation).toBeCloseTo(-5);
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,14 @@ app.use(express.json());
 
 let bazaarData = {};
 
+const TIMEFRAMES = {
+  '1m': 60 * 1000,
+  '1h': 60 * 60 * 1000,
+  '1d': 24 * 60 * 60 * 1000,
+  '1mo': 30 * 24 * 60 * 60 * 1000,
+  '1w': 7 * 24 * 60 * 60 * 1000,
+};
+
 if (!fs.existsSync(DATA_DIR)) {
   fs.mkdirSync(DATA_DIR, { recursive: true });
 }
@@ -95,6 +103,30 @@ app.get('/api/items', (req, res) => {
     quick_status: item.product?.quick_status || {},
   }));
   res.json(items);
+});
+
+app.get('/api/variations', (req, res) => {
+  const tf = TIMEFRAMES[req.query.timeframe] || TIMEFRAMES['1m'];
+  const threshold = Date.now() - tf;
+  const variations = Object.entries(bazaarData)
+    .map(([id, item]) => {
+      const history = item.history || [];
+      if (history.length === 0) {
+        return { id, variation: 0 };
+      }
+      const current = history[history.length - 1];
+      let past = null;
+      for (let i = history.length - 1; i >= 0; i--) {
+        if (history[i].time <= threshold) {
+          past = history[i];
+          break;
+        }
+      }
+      if (!past) past = history[0];
+      return { id, variation: (current.buyPrice || 0) - (past.buyPrice || 0) };
+    })
+    .sort((a, b) => b.variation - a.variation);
+  res.json(variations);
 });
 
 app.get('/api/items/:itemId', (req, res) => {


### PR DESCRIPTION
## Summary
- add timeframe constants and `/api/variations` endpoint on the server
- allow selecting timeframe in the client and fetch top variations from the server
- test the new variations endpoint

## Testing
- `npm run test`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6891695d5308832db653d3f94afaf100