### PR TITLE
feat: add neural tracking tab

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,7 @@ import { Container, Typography, Box, Tabs, Tab } from '@mui/material'
 import './App.css'
 import ItemList from './components/ItemList'
 import ItemChart from './components/ItemChart'
+import NeuralPrediction from './NeuralPrediction'
 
 function App() {
   const [tab, setTab] = useState(0)
@@ -84,6 +85,7 @@ function App() {
           <Tabs value={tab} onChange={(e, v) => setTab(v)} centered>
             <Tab label="Top Variation" />
             <Tab label="All Items" />
+            <Tab label="Neural Tracker" />
           </Tabs>
           {tab === 0 && (
             <Box mt={2}>
@@ -119,6 +121,23 @@ function App() {
                 ) : (
                   <ItemChart selectedItem={selectedItem} history={history} />
                 )}
+              </Box>
+            </Box>
+          )}
+          {tab === 2 && (
+            <Box mt={2} display="flex" gap={2}>
+              <Box width="30%" maxHeight={400} sx={{ overflowY: 'auto' }}>
+                <ItemList
+                  items={items}
+                  selectedItem={selectedItem}
+                  onItemSelect={setSelectedItem}
+                  getSecondary={(it) =>
+                    `Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`
+                  }
+                />
+              </Box>
+              <Box flexGrow={1}>
+                <NeuralPrediction itemId={selectedItem} />
               </Box>
             </Box>
           )}

--- a/client/src/NeuralPrediction.jsx
+++ b/client/src/NeuralPrediction.jsx
@@ -1,43 +1,57 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react'
 
 export default function NeuralPrediction({ itemId }) {
-  const [prediction, setPrediction] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const [info, setInfo] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
 
   useEffect(() => {
-    let mounted = true;
+    let mounted = true
     const fetchPrediction = async () => {
-      setLoading(true);
-      setError(null);
+      setLoading(true)
+      setError(null)
       try {
-        const res = await fetch(`/api/items/${itemId}/neural-prediction`);
-        if (!res.ok) throw new Error('Network response was not ok');
-        const data = await res.json();
-        if (mounted) setPrediction(data.predictedPrice);
+        const res = await fetch(`/api/items/${itemId}/neural-prediction`)
+        if (!res.ok) throw new Error('Network response was not ok')
+        const data = await res.json()
+        if (mounted) setInfo(data)
       } catch (err) {
-        if (mounted) setError(err.message);
+        if (mounted) setError(err.message)
       } finally {
-        if (mounted) setLoading(false);
+        if (mounted) setLoading(false)
       }
-    };
-    fetchPrediction();
+    }
+    fetchPrediction()
     return () => {
-      mounted = false;
-    };
-  }, [itemId]);
+      mounted = false
+    }
+  }, [itemId])
 
   if (loading) {
-    return <div>Loading...</div>;
+    return <div>Loading...</div>
   }
 
   if (error) {
-    return <div>Error: {error}</div>;
+    return <div>Error: {error}</div>
   }
 
-  if (prediction == null) {
-    return <div>No prediction available</div>;
+  if (!info) {
+    return <div>No prediction available</div>
   }
 
-  return <div>Prediction: {prediction.toFixed(2)}</div>;
+  return (
+    <div>
+      {info.predictedPrice != null ? (
+        <div>Prediction: {info.predictedPrice.toFixed(2)}</div>
+      ) : (
+        <div>No prediction available</div>
+      )}
+      {info.normalizedPrediction != null && (
+        <div>Normalized: {info.normalizedPrediction.toFixed(4)}</div>
+      )}
+      <div>Model Exists: {info.modelExists ? 'Yes' : 'No'}</div>
+      <div>Trained Now: {info.trained ? 'Yes' : 'No'}</div>
+      <div>Data Points: {info.dataPoints}</div>
+    </div>
+  )
 }

--- a/client/src/NeuralPrediction.test.jsx
+++ b/client/src/NeuralPrediction.test.jsx
@@ -2,16 +2,27 @@ import { render, screen, waitFor } from '@testing-library/react';
 import NeuralPrediction from './NeuralPrediction';
 import { vi } from 'vitest';
 
-test('fetches and displays prediction', async () => {
+test('fetches and displays detailed prediction info', async () => {
   const fakeFetch = vi.fn().mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve({ predictedPrice: 99 })
-  });
-  global.fetch = fakeFetch;
+    json: () =>
+      Promise.resolve({
+        predictedPrice: 99,
+        normalizedPrediction: 0.5,
+        modelExists: true,
+        trained: false,
+        dataPoints: 10,
+      }),
+  })
+  global.fetch = fakeFetch
 
-  render(<NeuralPrediction itemId="TEST" />);
+  render(<NeuralPrediction itemId="TEST" />)
   await waitFor(() => {
-    expect(screen.getByText(/Prediction:/)).toBeInTheDocument();
-  });
-  expect(screen.getByText('Prediction: 99.00')).toBeInTheDocument();
-});
+    expect(screen.getByText(/Prediction:/)).toBeInTheDocument()
+  })
+  expect(screen.getByText('Prediction: 99.00')).toBeInTheDocument()
+  expect(screen.getByText('Normalized: 0.5000')).toBeInTheDocument()
+  expect(screen.getByText('Model Exists: Yes')).toBeInTheDocument()
+  expect(screen.getByText('Trained Now: No')).toBeInTheDocument()
+  expect(screen.getByText('Data Points: 10')).toBeInTheDocument()
+})

--- a/server/__tests__/neural.test.js
+++ b/server/__tests__/neural.test.js
@@ -16,8 +16,10 @@ describe('neural model utilities', () => {
     const pred = await trainModel('TEST', data);
     expect(typeof pred).toBe('number');
     expect(fs.existsSync(modelFile)).toBe(true);
-    const again = await predictNext('TEST', data);
-    expect(typeof again).toBe('number');
+    const info = await predictNext('TEST', data);
+    expect(typeof info.prediction).toBe('number');
+    expect(info.modelExists).toBe(true);
+    expect(info.trained).toBe(false);
   });
 });
 

--- a/server/__tests__/route.test.js
+++ b/server/__tests__/route.test.js
@@ -23,10 +23,13 @@ describe('GET /api/items/:id/neural-prediction', () => {
     }
   });
 
-  test('returns predicted price', async () => {
+  test('returns predicted price with details', async () => {
     const res = await request(app).get('/api/items/TEST/neural-prediction');
     expect(res.status).toBe(200);
     expect(res.body.predictedPrice).toBeGreaterThan(30);
     expect(res.body.predictedPrice).toBeLessThanOrEqual(40);
+    expect(res.body.modelExists).toBe(false);
+    expect(res.body.trained).toBe(true);
+    expect(res.body.dataPoints).toBe(4);
   });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -120,12 +120,24 @@ app.get('/api/items/:itemId/neural-prediction', async (req, res) => {
   if (normalized.length < 3) {
     return res.json({});
   }
-  const predictedNorm = await predictNext(itemId, normalized);
+  const { prediction, modelExists, trained, dataPoints } = await predictNext(
+    itemId,
+    normalized
+  );
+  if (prediction == null) {
+    return res.json({ modelExists, trained, dataPoints });
+  }
   const prices = history.map((h) => h.buyPrice);
   const max = Math.max(...prices);
   const min = Math.min(...prices);
-  const predictedPrice = predictedNorm * (max - min) + min;
-  res.json({ predictedPrice });
+  const predictedPrice = prediction * (max - min) + min;
+  res.json({
+    predictedPrice,
+    normalizedPrediction: prediction,
+    modelExists,
+    trained,
+    dataPoints,
+  });
 });
 
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- expose model status, training flag, and data size from neural prediction endpoint
- show detailed neural prediction info and add a new Neural Tracker tab in the client

## Testing
- `npm run test:server`
- `npm run test:client`


------
https://chatgpt.com/codex/tasks/task_e_689169df5dc4832d8c401f879eadca2d