### PR TITLE
feat(ui): expand theme and apply design system

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,5 +1,6 @@
 .App {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 2rem;
+  background-color: var(--mui-palette-background-default);
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Container, Typography, Box, Tabs, Tab } from '@mui/material'
+import { Container, Typography, Box, Tabs, Tab, Card } from '@mui/material'
 import './App.css'
 import ItemList from './components/ItemList'
 import ItemChart from './components/ItemChart'
@@ -99,7 +99,7 @@ function App() {
           )}
           {tab === 1 && (
             <Box mt={2} display="flex" gap={2}>
-              <Box width="30%" maxHeight={400} sx={{ overflowY: 'auto' }}>
+              <Card sx={{ width: '30%', maxHeight: 400, overflowY: 'auto', p: 0 }}>
                 <ItemList
                   items={items}
                   selectedItem={selectedItem}
@@ -108,18 +108,24 @@ function App() {
                     `Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`
                   }
                 />
-              </Box>
-              <Box flexGrow={1}>
-                {historyError ? (
+              </Card>
+              {historyError ? (
+                <Card sx={{ flexGrow: 1, p: 2 }}>
                   <Typography color="error">
                     Error loading history: {historyError}
                   </Typography>
-                ) : historyLoading ? (
+                </Card>
+              ) : historyLoading ? (
+                <Card sx={{ flexGrow: 1, p: 2 }}>
                   <Typography>Loading history...</Typography>
-                ) : (
-                  <ItemChart selectedItem={selectedItem} history={history} />
-                )}
-              </Box>
+                </Card>
+              ) : (
+                <ItemChart
+                  selectedItem={selectedItem}
+                  history={history}
+                  sx={{ flexGrow: 1 }}
+                />
+              )}
             </Box>
           )}
         </>

--- a/client/src/components/ItemChart.jsx
+++ b/client/src/components/ItemChart.jsx
@@ -1,9 +1,10 @@
-import { Paper, Typography, Box } from '@mui/material'
+import { Card, Typography, Box, useTheme } from '@mui/material'
 import { Line } from 'react-chartjs-2'
 import 'chart.js/auto'
 import NeuralPrediction from '../NeuralPrediction'
 
-function ItemChart({ selectedItem, history }) {
+function ItemChart({ selectedItem, history, sx = {} }) {
+  const theme = useTheme()
   if (!selectedItem) return null
 
   const chartData = {
@@ -12,20 +13,20 @@ function ItemChart({ selectedItem, history }) {
       {
         label: 'Buy Price',
         data: history.map((h) => h.buyPrice),
-        borderColor: 'rgb(75,192,192)',
+        borderColor: theme.palette.success.main,
         fill: false,
       },
       {
         label: 'Sell Price',
         data: history.map((h) => h.sellPrice),
-        borderColor: 'rgb(192,75,75)',
+        borderColor: theme.palette.error.main,
         fill: false,
       },
     ],
   }
 
   return (
-    <Paper sx={{ p: 2 }}>
+    <Card sx={{ p: 2, ...sx }}>
       <Typography variant="h6" align="center" gutterBottom>
         {selectedItem}
       </Typography>
@@ -35,7 +36,7 @@ function ItemChart({ selectedItem, history }) {
       <Box mt={2}>
         <NeuralPrediction itemId={selectedItem} />
       </Box>
-    </Paper>
+    </Card>
   )
 }
 

--- a/client/src/components/ItemList.jsx
+++ b/client/src/components/ItemList.jsx
@@ -1,13 +1,16 @@
-import { List, ListItemButton, ListItemText } from '@mui/material'
+import { List, ListItemButton, ListItemText, useTheme } from '@mui/material'
 
 function ItemList({ items, onItemSelect, selectedItem, getSecondary }) {
+  const theme = useTheme()
+
   return (
-    <List>
+    <List sx={{ bgcolor: 'background.paper' }}>
       {items.map((item) => (
         <ListItemButton
           key={item.id}
           selected={selectedItem === item.id}
           onClick={() => onItemSelect(item.id)}
+          sx={{ mb: theme.spacing(0.5), borderRadius: 1 }}
         >
           <ListItemText
             primary={item.id}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,7 +1,12 @@
 body {
   margin: 0;
+  font-family: 'Roboto, sans-serif';
+  background-color: var(--mui-palette-background-default);
+  color: var(--mui-palette-text-primary);
 }
 
 #root {
   min-height: 100vh;
+  padding: 1rem;
+  background-color: inherit;
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -10,6 +10,15 @@ const theme = createTheme({
     primary: {
       main: '#1976d2',
     },
+    success: {
+      main: '#2e7d32',
+    },
+    error: {
+      main: '#d32f2f',
+    },
+    warning: {
+      main: '#ed6c02',
+    },
     background: {
       default: '#121212',
       paper: '#1e1e1e',
@@ -18,11 +27,34 @@ const theme = createTheme({
   typography: {
     fontFamily: 'Roboto, sans-serif',
     h1: {
+      fontSize: '2.5rem',
+      fontWeight: 700,
+    },
+    h2: {
       fontSize: '2rem',
+      fontWeight: 600,
+    },
+    h3: {
+      fontSize: '1.75rem',
       fontWeight: 500,
+    },
+    h4: {
+      fontSize: '1.5rem',
+      fontWeight: 500,
+    },
+    h5: {
+      fontSize: '1.25rem',
+      fontWeight: 400,
+    },
+    h6: {
+      fontSize: '1.1rem',
+      fontWeight: 400,
     },
     body1: {
       fontSize: '1rem',
+    },
+    body2: {
+      fontSize: '0.875rem',
     },
   },
   spacing: 4,
@@ -32,6 +64,41 @@ const theme = createTheme({
         root: {
           borderRadius: 8,
           textTransform: 'none',
+        },
+      },
+    },
+    MuiList: {
+      styleOverrides: {
+        root: {
+          paddingTop: 0,
+          paddingBottom: 0,
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          padding: 16,
+          borderRadius: 8,
+        },
+      },
+    },
+    MuiTabs: {
+      styleOverrides: {
+        root: {
+          minHeight: 48,
+        },
+        indicator: {
+          height: 3,
+          borderRadius: 3,
+        },
+      },
+    },
+    MuiTab: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          minHeight: 48,
         },
       },
     },


### PR DESCRIPTION
## Summary
- expand MUI theme with status palette, typography scale, and list/card/tab overrides
- apply theme-driven styling to All Items list and chart components
- align global styles with design tokens for fonts, spacing, and backgrounds

## Testing
- `npm run test:server`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68916a131ffc832d90e2247ea7e3ea4a