### PR TITLE
Show item data when selecting an item

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,7 @@ import { Container, Typography, Box, Tabs, Tab } from '@mui/material'
 import './App.css'
 import ItemList from './components/ItemList'
 import ItemChart from './components/ItemChart'
+import ItemDetails from './components/ItemDetails'
 
 function App() {
   const [tab, setTab] = useState(0)
@@ -109,7 +110,8 @@ function App() {
                   }
                 />
               </Box>
-              <Box flexGrow={1}>
+              <Box flexGrow={1} display="flex" flexDirection="column" gap={2}>
+                <ItemDetails item={items.find((it) => it.id === selectedItem)} />
                 {historyError ? (
                   <Typography color="error">
                     Error loading history: {historyError}

--- a/client/src/ItemDetails.test.jsx
+++ b/client/src/ItemDetails.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import ItemDetails from './components/ItemDetails'
+
+test('renders item JSON data', () => {
+  const item = { id: 'FOO', foo: 'bar' }
+  render(<ItemDetails item={item} />)
+  expect(screen.getByText(/Item Data/i)).toBeInTheDocument()
+  expect(screen.getByText(/"id": "FOO"/)).toBeInTheDocument()
+})
+

--- a/client/src/components/ItemDetails.jsx
+++ b/client/src/components/ItemDetails.jsx
@@ -1,0 +1,16 @@
+import { Paper, Typography } from '@mui/material'
+
+function ItemDetails({ item }) {
+  if (!item) return null
+
+  return (
+    <Paper sx={{ p: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        Item Data
+      </Typography>
+      <pre>{JSON.stringify(item, null, 2)}</pre>
+    </Paper>
+  )
+}
+
+export default ItemDetails


### PR DESCRIPTION
## Summary
- add `ItemDetails` component to display all data for a selected item
- integrate `ItemDetails` into the All Items view so clicking an item reveals its data
- cover `ItemDetails` with a simple unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689169b4965c832d800c16634fa1a1cc