### PR TITLE
feat: add card-based item list

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -58,12 +58,11 @@ function App() {
   }, [selectedItem, fetchHistory])
 
   const variations = [...items]
-    .map((it) => ({
-      id: it.id,
-      variation:
-        (it.quick_status.sellPrice || 0) - (it.quick_status.buyPrice || 0),
-    }))
-    .sort((a, b) => b.variation - a.variation)
+    .sort(
+      (a, b) =>
+        (b.quick_status.sellPrice || 0) - (b.quick_status.buyPrice || 0) -
+        ((a.quick_status.sellPrice || 0) - (a.quick_status.buyPrice || 0))
+    )
     .slice(0, 10)
 
   return (
@@ -89,11 +88,11 @@ function App() {
             <Box mt={2}>
               <ItemList
                 items={variations}
+                selectedItem={selectedItem}
                 onItemSelect={(id) => {
                   setSelectedItem(id)
                   setTab(1)
                 }}
-                getSecondary={(v) => `Variation: ${v.variation.toFixed(2)}`}
               />
             </Box>
           )}
@@ -104,9 +103,6 @@ function App() {
                   items={items}
                   selectedItem={selectedItem}
                   onItemSelect={setSelectedItem}
-                  getSecondary={(it) =>
-                    `Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`
-                  }
                 />
               </Box>
               <Box flexGrow={1}>

--- a/client/src/components/ItemCard.jsx
+++ b/client/src/components/ItemCard.jsx
@@ -1,0 +1,43 @@
+import { Card, CardActionArea, CardContent, Typography, Box } from '@mui/material'
+
+function formatName(id) {
+  return id
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+function ItemCard({ item, selected, onClick }) {
+  const buy = item.quick_status?.buyPrice ?? 0
+  const sell = item.quick_status?.sellPrice ?? 0
+  const variation = item.variation ?? sell - buy
+  const variationColor =
+    variation > 0 ? 'success.main' : variation < 0 ? 'error.main' : 'text.primary'
+
+  return (
+    <Card
+      variant={selected ? 'outlined' : 'elevation'}
+      sx={{
+        borderColor: selected ? 'primary.main' : 'transparent',
+        backgroundColor: selected ? 'action.selected' : 'background.paper',
+      }}
+    >
+      <CardActionArea onClick={onClick}>
+        <CardContent sx={{ '&:last-child': { pb: 2 } }}>
+          <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+            {formatName(item.id)}
+          </Typography>
+          <Box display="flex" justifyContent="space-between" mb={1}>
+            <Typography variant="body2">Buy: {buy.toFixed(1)}</Typography>
+            <Typography variant="body2">Sell: {sell.toFixed(1)}</Typography>
+          </Box>
+          <Typography variant="body2" color={variationColor}>
+            Variation: {variation.toFixed(2)}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  )
+}
+
+export default ItemCard

--- a/client/src/components/ItemList.jsx
+++ b/client/src/components/ItemList.jsx
@@ -1,21 +1,19 @@
-import { List, ListItemButton, ListItemText } from '@mui/material'
+import { Grid } from '@mui/material'
+import ItemCard from './ItemCard'
 
-function ItemList({ items, onItemSelect, selectedItem, getSecondary }) {
+function ItemList({ items, onItemSelect, selectedItem }) {
   return (
-    <List>
+    <Grid container spacing={2}>
       {items.map((item) => (
-        <ListItemButton
-          key={item.id}
-          selected={selectedItem === item.id}
-          onClick={() => onItemSelect(item.id)}
-        >
-          <ListItemText
-            primary={item.id}
-            secondary={getSecondary ? getSecondary(item) : null}
+        <Grid item xs={12} sm={6} md={4} key={item.id}>
+          <ItemCard
+            item={item}
+            selected={selectedItem === item.id}
+            onClick={() => onItemSelect(item.id)}
           />
-        </ListItemButton>
+        </Grid>
       ))}
-    </List>
+    </Grid>
   )
 }
 


### PR DESCRIPTION
## Summary
- add `ItemCard` for formatted name, price, and variation display
- render item lists as a responsive grid of cards with selection highlighting
- compute top variations from item data and update list usage

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68916a12e240832da85df56123e41996