### PR TITLE
fix: remove stray lines in App imports

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,11 +3,9 @@ import { Container, Typography, Box, Tabs, Tab, Select, MenuItem } from '@mui/ma
 import './App.css'
 import ItemList from './components/ItemList'
 import ItemChart from './components/ItemChart'
-wl6ai6-codex/show-item-data-on-press
 import ItemDetails from './components/ItemDetails'
 
 import NeuralPrediction from './NeuralPrediction'
-main
 
 function App() {
   const [tab, setTab] = useState(0)


### PR DESCRIPTION
## Summary
- clean App imports by removing stray lines

## Testing
- `npm test` *(fails: volatility model utilities trains model and makes volatility prediction, GET /api/items/:id/volatility-prediction returns predicted volatility)*
- `npm run lint --prefix client` *(fails: 'test' is not defined, 'expect' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689170c2cb10832daad261b30c4d257a