### PR TITLE
Guard predictions when item not selected

### DIFF
--- a/client/src/NeuralPrediction.jsx
+++ b/client/src/NeuralPrediction.jsx
@@ -6,6 +6,7 @@ export default function NeuralPrediction({ itemId }) {
   const [error, setError] = useState(null)
 
   useEffect(() => {
+    if (!itemId) return
     let mounted = true
     const fetchPrediction = async () => {
       setLoading(true)
@@ -26,6 +27,10 @@ export default function NeuralPrediction({ itemId }) {
       mounted = false
     }
   }, [itemId])
+
+  if (!itemId) {
+    return <div>No item selected</div>
+  }
 
   if (loading) {
     return <div>Loading...</div>

--- a/client/src/NeuralPrediction.test.jsx
+++ b/client/src/NeuralPrediction.test.jsx
@@ -26,3 +26,13 @@ test('fetches and displays detailed prediction info', async () => {
   expect(screen.getByText('Trained Now: No')).toBeInTheDocument()
   expect(screen.getByText('Data Points: 10')).toBeInTheDocument()
 })
+
+test('renders placeholder when no item is selected', () => {
+  const fakeFetch = vi.fn()
+  global.fetch = fakeFetch
+
+  render(<NeuralPrediction />)
+
+  expect(screen.getByText('No item selected')).toBeInTheDocument()
+  expect(fakeFetch).not.toHaveBeenCalled()
+})

--- a/client/src/VolatilityPrediction.jsx
+++ b/client/src/VolatilityPrediction.jsx
@@ -6,6 +6,7 @@ export default function VolatilityPrediction({ itemId }) {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    if (!itemId) return;
     let mounted = true;
     const fetchVolatility = async () => {
       setLoading(true);
@@ -26,6 +27,10 @@ export default function VolatilityPrediction({ itemId }) {
       mounted = false;
     };
   }, [itemId]);
+
+  if (!itemId) {
+    return <div>No item selected</div>;
+  }
 
   if (loading) {
     return <div>Loading...</div>;

--- a/client/src/VolatilityPrediction.test.jsx
+++ b/client/src/VolatilityPrediction.test.jsx
@@ -15,3 +15,13 @@ test('fetches and displays volatility prediction', async () => {
   });
   expect(screen.getByText('Volatility: 5.00')).toBeInTheDocument();
 });
+
+test('renders placeholder when no item is selected', () => {
+  const fakeFetch = vi.fn();
+  global.fetch = fakeFetch;
+
+  render(<VolatilityPrediction />);
+
+  expect(screen.getByText('No item selected')).toBeInTheDocument();
+  expect(fakeFetch).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- Skip prediction fetches when no item is selected in NeuralPrediction and VolatilityPrediction
- Show placeholder message for unselected items
- Add tests for placeholder rendering

## Testing
- `npm test` *(fails: volatility model utilities › trains model and makes volatility prediction; GET /api/items/:id/volatility-prediction › returns predicted volatility)*
- `npm run test:client`


------
https://chatgpt.com/codex/tasks/task_e_689170d30780832da2f2bcbf304827d7