### PR TITLE
Dispose tensors in neural utils

### DIFF
--- a/server/__tests__/neural.test.js
+++ b/server/__tests__/neural.test.js
@@ -6,6 +6,7 @@ const {
   trainVolatilityModel,
   predictVolatility,
 } = require('../utils/neural');
+const tf = require('@tensorflow/tfjs');
 
 describe('neural model utilities', () => {
   const modelFile = path.join(__dirname, '../data/TEST-model.json');
@@ -25,6 +26,17 @@ describe('neural model utilities', () => {
     expect(typeof info.prediction).toBe('number');
     expect(info.modelExists).toBe(true);
     expect(info.trained).toBe(false);
+  });
+
+  test('tensor count remains stable across predictions', async () => {
+    const data = [0.1, 0.2, 0.3, 0.4];
+    await trainModel('TEST', data);
+    await predictNext('TEST', data); // warm up
+    const start = tf.memory().numTensors;
+    for (let i = 0; i < 5; i++) {
+      await predictNext('TEST', data);
+    }
+    expect(tf.memory().numTensors).toBe(start);
   });
 });
 


### PR DESCRIPTION
## Summary
- manage memory in neural network utils by disposing intermediate tensors and models
- return numeric volatility prediction and verify tensor counts stay stable over repeated use
- add regression test to assert tensor counts don't grow across predictions

## Testing
- `npm test`
- `node - <<'NODE'
const fs=require('fs');
const path=require('path');
const tf=require('@tensorflow/tfjs');
const {trainModel,predictNext}=require('./server/utils/neural');
(async()=>{
 const id='TMP';
 const modelFile=path.join(__dirname,'server/data/','TMP-model.json');
 const data=[0.1,0.2,0.3,0.4];
 await trainModel(id,data);
 await predictNext(id,data);
 const start=tf.memory().numTensors;
 for(let i=0;i<5;i++) await predictNext(id,data);
 const end=tf.memory().numTensors;
 console.log('start',start,'end',end);
 if(fs.existsSync(modelFile)) fs.unlinkSync(modelFile);
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689170d4d46c832db9992003cb57a7a7