### PR TITLE
feat: improve item details display

### DIFF
--- a/client/src/ItemDetails.test.jsx
+++ b/client/src/ItemDetails.test.jsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react'
 import ItemDetails from './components/ItemDetails'
 
-test('renders item JSON data', () => {
+test('renders item details', () => {
   const item = { id: 'FOO', foo: 'bar' }
   render(<ItemDetails item={item} />)
   expect(screen.getByText(/Item Data/i)).toBeInTheDocument()
-  expect(screen.getByText(/"id": "FOO"/)).toBeInTheDocument()
+  expect(screen.getByText(/id:/i)).toBeInTheDocument()
+  expect(screen.getByText('FOO')).toBeInTheDocument()
 })
 

--- a/client/src/components/ItemDetails.jsx
+++ b/client/src/components/ItemDetails.jsx
@@ -1,14 +1,31 @@
-import { Paper, Typography } from '@mui/material'
+import { Box, Paper, Typography } from '@mui/material'
 
 function ItemDetails({ item }) {
   if (!item) return null
+
+  const renderObject = (obj, indent = 0) => (
+    Object.entries(obj).map(([key, value]) =>
+      typeof value === 'object' && value !== null ? (
+        <Box key={key} sx={{ pl: indent }}>
+          <Typography sx={{ fontWeight: 'bold' }}>{key}</Typography>
+          {renderObject(value, indent + 2)}
+        </Box>
+      ) : (
+        <Box key={key} sx={{ pl: indent }}>
+          <Typography>
+            <strong>{key}:</strong> {String(value)}
+          </Typography>
+        </Box>
+      )
+    )
+  )
 
   return (
     <Paper sx={{ p: 2 }}>
       <Typography variant="h6" gutterBottom>
         Item Data
       </Typography>
-      <pre>{JSON.stringify(item, null, 2)}</pre>
+      {renderObject(item)}
     </Paper>
   )
 }


### PR DESCRIPTION
## Summary
- render item details with nested formatting for readability
- update ItemDetails test to verify new output

## Testing
- `npm test` *(fails: expect(Number.isFinite(...)) to be true and expect(typeof info.prediction) to be 'number')*

------
https://chatgpt.com/codex/tasks/task_e_689176f0cd30832d8cd64bd4e46f9b82