### PR TITLE
Fix volatility prediction output

### DIFF
--- a/server/utils/neural.js
+++ b/server/utils/neural.js
@@ -114,11 +114,10 @@ async function trainVolatilityModel(itemId, normalizedChanges) {
 }
 
 async function predictVolatility(itemId, normalizedChanges) {
-  const { prediction } = await predictNext(
+  return predictNext(
     withSuffix(itemId, 'VOLATILITY'),
     normalizedChanges
   );
-  return prediction;
 }
 
 module.exports = { trainModel, predictNext, trainVolatilityModel, predictVolatility };


### PR DESCRIPTION
## Summary
- fix volatility prediction so routes receive prediction metadata

## Testing
- `npm run test:server`
- `npm run test:client`


------
https://chatgpt.com/codex/tasks/task_e_689182ed3b6c832da3fa1b7d8b281d0a