### PR TITLE
Improve prediction component reliability and responsive layout

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,16 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Container, Typography, Box, Tabs, Tab, Select, MenuItem } from '@mui/material'
+import {
+  Container,
+  Typography,
+  Box,
+  Tabs,
+  Tab,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  useMediaQuery,
+} from '@mui/material'
 import './App.css'
 import ItemList from './components/ItemList'
 import ItemChart from './components/ItemChart'
@@ -20,6 +31,7 @@ function App() {
   const [variations, setVariations] = useState([])
   const [variationsLoading, setVariationsLoading] = useState(false)
   const [variationsError, setVariationsError] = useState(null)
+  const isMobile = useMediaQuery('(max-width:600px)')
 
   useEffect(() => {
     const fetchItems = async () => {
@@ -141,17 +153,44 @@ function App() {
             </Box>
           )}
           {tab === 1 && (
-            <Box mt={2} display="flex" gap={2}>
-              <Box width="30%" maxHeight={400} sx={{ overflowY: 'auto' }}>
-                <ItemList
-                  items={items}
-                  selectedItem={selectedItem}
-                  onItemSelect={setSelectedItem}
-                  getSecondary={(it) =>
-                    `Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`
-                  }
-                />
-              </Box>
+            <Box
+              mt={2}
+              display="flex"
+              gap={2}
+              flexDirection={isMobile ? 'column' : 'row'}
+            >
+              {isMobile ? (
+                <FormControl fullWidth size="small">
+                  <InputLabel id="item-select-label">Item</InputLabel>
+                  <Select
+                    labelId="item-select-label"
+                    label="Item"
+                    value={selectedItem || ''}
+                    onChange={(e) => setSelectedItem(e.target.value)}
+                  >
+                    {items.map((it) => (
+                      <MenuItem key={it.id} value={it.id}>
+                        {it.id}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              ) : (
+                <Box
+                  width="30%"
+                  maxHeight={400}
+                  sx={{ overflowY: 'auto' }}
+                >
+                  <ItemList
+                    items={items}
+                    selectedItem={selectedItem}
+                    onItemSelect={setSelectedItem}
+                    getSecondary={(it) =>
+                      `Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`
+                    }
+                  />
+                </Box>
+              )}
               <Box flexGrow={1} display="flex" flexDirection="column" gap={2}>
                 <ItemDetails item={items.find((it) => it.id === selectedItem)} />
                 {historyError ? (
@@ -167,17 +206,44 @@ function App() {
             </Box>
           )}
           {tab === 2 && (
-            <Box mt={2} display="flex" gap={2}>
-              <Box width="30%" maxHeight={400} sx={{ overflowY: 'auto' }}>
-                <ItemList
-                  items={items}
-                  selectedItem={selectedItem}
-                  onItemSelect={setSelectedItem}
-                  getSecondary={(it) =>
-                    `Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`
-                  }
-                />
-              </Box>
+            <Box
+              mt={2}
+              display="flex"
+              gap={2}
+              flexDirection={isMobile ? 'column' : 'row'}
+            >
+              {isMobile ? (
+                <FormControl fullWidth size="small">
+                  <InputLabel id="neural-item-select-label">Item</InputLabel>
+                  <Select
+                    labelId="neural-item-select-label"
+                    label="Item"
+                    value={selectedItem || ''}
+                    onChange={(e) => setSelectedItem(e.target.value)}
+                  >
+                    {items.map((it) => (
+                      <MenuItem key={it.id} value={it.id}>
+                        {it.id}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              ) : (
+                <Box
+                  width="30%"
+                  maxHeight={400}
+                  sx={{ overflowY: 'auto' }}
+                >
+                  <ItemList
+                    items={items}
+                    selectedItem={selectedItem}
+                    onItemSelect={setSelectedItem}
+                    getSecondary={(it) =>
+                      `Buy: ${(it.quick_status.buyPrice || 0).toFixed(1)} Sell: ${(it.quick_status.sellPrice || 0).toFixed(1)}`
+                    }
+                  />
+                </Box>
+              )}
               <Box flexGrow={1}>
                 <NeuralPrediction itemId={selectedItem} />
               </Box>

--- a/client/src/NeuralPrediction.jsx
+++ b/client/src/NeuralPrediction.jsx
@@ -6,18 +6,28 @@ export default function NeuralPrediction({ itemId }) {
   const [error, setError] = useState(null)
 
   useEffect(() => {
-    if (!itemId) return
+    if (!itemId || typeof itemId !== 'string') {
+      setError('Invalid item ID')
+      setInfo(null)
+      return
+    }
     let mounted = true
     const fetchPrediction = async () => {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch(`/api/items/${itemId}/neural-prediction`)
-        if (!res.ok) throw new Error('Network response was not ok')
+        const res = await fetch(
+          `/api/items/${encodeURIComponent(itemId)}/neural-prediction`
+        )
+        if (!res.ok) {
+          let message = 'Failed to load prediction'
+          if (res.status === 404) message = 'Prediction not found'
+          throw new Error(message)
+        }
         const data = await res.json()
         if (mounted) setInfo(data)
       } catch (err) {
-        if (mounted) setError(err.message)
+        if (mounted) setError(err.message || 'Unknown error')
       } finally {
         if (mounted) setLoading(false)
       }

--- a/client/src/NeuralPrediction.test.jsx
+++ b/client/src/NeuralPrediction.test.jsx
@@ -36,3 +36,23 @@ test('renders placeholder when no item is selected', () => {
   expect(screen.getByText('No item selected')).toBeInTheDocument()
   expect(fakeFetch).not.toHaveBeenCalled()
 })
+
+test('handles API errors gracefully', async () => {
+  const fakeFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 })
+  global.fetch = fakeFetch
+
+  render(<NeuralPrediction itemId="TEST" />)
+
+  await waitFor(() => {
+    expect(screen.getByText(/Error:/)).toBeInTheDocument()
+  })
+  expect(screen.getByText('Error: Failed to load prediction')).toBeInTheDocument()
+})
+
+test('shows error for invalid item id', async () => {
+  render(<NeuralPrediction itemId={123} />)
+
+  await waitFor(() => {
+    expect(screen.getByText('Error: Invalid item ID')).toBeInTheDocument()
+  })
+})

--- a/client/src/VolatilityPrediction.jsx
+++ b/client/src/VolatilityPrediction.jsx
@@ -6,18 +6,28 @@ export default function VolatilityPrediction({ itemId }) {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    if (!itemId) return;
+    if (!itemId || typeof itemId !== 'string') {
+      setError('Invalid item ID');
+      setVolatility(null);
+      return;
+    }
     let mounted = true;
     const fetchVolatility = async () => {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(`/api/items/${itemId}/volatility-prediction`);
-        if (!res.ok) throw new Error('Network response was not ok');
+        const res = await fetch(
+          `/api/items/${encodeURIComponent(itemId)}/volatility-prediction`
+        );
+        if (!res.ok) {
+          let message = 'Failed to load prediction';
+          if (res.status === 404) message = 'Prediction not found';
+          throw new Error(message);
+        }
         const data = await res.json();
         if (mounted) setVolatility(data.predictedVolatility);
       } catch (err) {
-        if (mounted) setError(err.message);
+        if (mounted) setError(err.message || 'Unknown error');
       } finally {
         if (mounted) setLoading(false);
       }

--- a/client/src/VolatilityPrediction.test.jsx
+++ b/client/src/VolatilityPrediction.test.jsx
@@ -25,3 +25,23 @@ test('renders placeholder when no item is selected', () => {
   expect(screen.getByText('No item selected')).toBeInTheDocument();
   expect(fakeFetch).not.toHaveBeenCalled();
 });
+
+test('handles API errors gracefully', async () => {
+  const fakeFetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+  global.fetch = fakeFetch;
+
+  render(<VolatilityPrediction itemId="BAD" />);
+
+  await waitFor(() => {
+    expect(screen.getByText(/Error:/)).toBeInTheDocument();
+  });
+  expect(screen.getByText('Error: Prediction not found')).toBeInTheDocument();
+});
+
+test('shows error for invalid item id', async () => {
+  render(<VolatilityPrediction itemId={123} />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Error: Invalid item ID')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Handle invalid item IDs and server errors in neural and volatility predictions
- Replace item list with mobile-friendly dropdowns and media queries
- Add tests covering API failures and invalid item handling

## Testing
- `npm run test:server`
- `npm run test:client`


------
https://chatgpt.com/codex/tasks/task_e_68918a276714832d98e71914463b4229