### PR TITLE
Encode item IDs in fetch requests to fix neural prediction

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -46,7 +46,9 @@ function App() {
     setHistoryLoading(true)
     setHistoryError(null)
     try {
-      const res = await fetch(`http://localhost:3001/api/items/${id}`)
+      const res = await fetch(
+        `http://localhost:3001/api/items/${encodeURIComponent(id)}`
+      )
       if (!res.ok) throw new Error('Network response was not ok')
       const json = await res.json()
       setHistory(json)

--- a/client/src/NeuralPrediction.jsx
+++ b/client/src/NeuralPrediction.jsx
@@ -12,7 +12,9 @@ export default function NeuralPrediction({ itemId }) {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch(`/api/items/${itemId}/neural-prediction`)
+        const res = await fetch(
+          `/api/items/${encodeURIComponent(itemId)}/neural-prediction`
+        )
         if (!res.ok) throw new Error('Network response was not ok')
         const data = await res.json()
         if (mounted) setInfo(data)

--- a/client/src/NeuralPrediction.test.jsx
+++ b/client/src/NeuralPrediction.test.jsx
@@ -36,3 +36,19 @@ test('renders placeholder when no item is selected', () => {
   expect(screen.getByText('No item selected')).toBeInTheDocument()
   expect(fakeFetch).not.toHaveBeenCalled()
 })
+
+test('encodes itemId in request URL', async () => {
+  const fakeFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({}),
+  })
+  global.fetch = fakeFetch
+
+  render(<NeuralPrediction itemId="BAD ITEM" />)
+  await waitFor(() => {
+    expect(fakeFetch).toHaveBeenCalled()
+  })
+  expect(fakeFetch).toHaveBeenCalledWith(
+    '/api/items/BAD%20ITEM/neural-prediction'
+  )
+})

--- a/client/src/VolatilityPrediction.jsx
+++ b/client/src/VolatilityPrediction.jsx
@@ -12,7 +12,9 @@ export default function VolatilityPrediction({ itemId }) {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(`/api/items/${itemId}/volatility-prediction`);
+        const res = await fetch(
+          `/api/items/${encodeURIComponent(itemId)}/volatility-prediction`
+        );
         if (!res.ok) throw new Error('Network response was not ok');
         const data = await res.json();
         if (mounted) setVolatility(data.predictedVolatility);

--- a/client/src/VolatilityPrediction.test.jsx
+++ b/client/src/VolatilityPrediction.test.jsx
@@ -25,3 +25,19 @@ test('renders placeholder when no item is selected', () => {
   expect(screen.getByText('No item selected')).toBeInTheDocument();
   expect(fakeFetch).not.toHaveBeenCalled();
 });
+
+test('encodes itemId in request URL', async () => {
+  const fakeFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({}),
+  });
+  global.fetch = fakeFetch;
+
+  render(<VolatilityPrediction itemId="BAD ITEM" />);
+  await waitFor(() => {
+    expect(fakeFetch).toHaveBeenCalled();
+  });
+  expect(fakeFetch).toHaveBeenCalledWith(
+    '/api/items/BAD%20ITEM/volatility-prediction'
+  );
+});


### PR DESCRIPTION
## Summary
- Encode item IDs in client-side API calls so URLs remain valid for items with spaces or special characters.
- Ensure history fetch and neural/volatility prediction requests handle encoded IDs.
- Add tests verifying URL encoding and updated components.

## Testing
- `npm run test:server`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68918922fa10832da273cf84e91b1aaa