### PR TITLE
feat: add loading skeletons

### DIFF
--- a/frontend/src/components/ItemListSkeleton.tsx
+++ b/frontend/src/components/ItemListSkeleton.tsx
@@ -1,0 +1,11 @@
+export default function ItemListSkeleton() {
+  return (
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="border p-2 rounded animate-pulse">
+          <div className="h-4 bg-gray-300 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ItemSkeleton.tsx
+++ b/frontend/src/components/ItemSkeleton.tsx
@@ -1,0 +1,12 @@
+export default function ItemSkeleton() {
+  return (
+    <div className="space-y-2 animate-pulse">
+      <div className="h-6 w-1/3 bg-gray-300 rounded" />
+      <ul className="space-y-1">
+        {Array.from({ length: 10 }).map((_, i) => (
+          <li key={i} className="h-4 bg-gray-300 rounded" />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/VariationListSkeleton.tsx
+++ b/frontend/src/components/VariationListSkeleton.tsx
@@ -1,0 +1,12 @@
+export default function VariationListSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 10 }).map((_, i) => (
+        <div key={i} className="flex justify-between border-b pb-1 animate-pulse">
+          <div className="h-4 w-1/3 bg-gray-300 rounded" />
+          <div className="h-4 w-10 bg-gray-300 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import VariationListSkeleton from '../components/VariationListSkeleton';
 
 interface Variation {
   id: string;
@@ -14,7 +15,7 @@ export default function Analytics() {
     return res.data;
   });
 
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading) return <VariationListSkeleton />;
   if (error) return <div>Error loading analytics.</div>;
 
   return (

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import ItemListSkeleton from '../components/ItemListSkeleton';
 
 interface Item {
   id: string;
@@ -7,10 +8,13 @@ interface Item {
 }
 
 export default function Dashboard() {
-  const { data } = useQuery<Item[]>(['items'], async () => {
+  const { data, isLoading, error } = useQuery<Item[]>(['items'], async () => {
     const res = await axios.get('/items');
     return res.data;
   });
+
+  if (isLoading) return <ItemListSkeleton />;
+  if (error) return <div>Error loading items.</div>;
 
   return (
     <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">

--- a/frontend/src/pages/Item.tsx
+++ b/frontend/src/pages/Item.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import ItemSkeleton from '../components/ItemSkeleton';
 
 export default function Item() {
   const { id } = useParams();
@@ -13,7 +14,7 @@ export default function Item() {
     { enabled: !!id }
   );
 
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading) return <ItemSkeleton />;
   if (error) return <div>Error loading item.</div>;
   if (!data || data.length === 0) return <div>No data for {id}</div>;
 


### PR DESCRIPTION
## Summary
- add skeleton components for item lists, item details and variations
- show skeletons while Dashboard, Item and Analytics queries load

## Testing
- `npm test --prefix frontend`
- `npm test`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68918d3b7900832db0aac7302e6e4130