### PR TITLE
feat: add EMA helper and endpoint

### DIFF
--- a/server/__tests__/ema.test.js
+++ b/server/__tests__/ema.test.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+const { app, bazaarData } = require('../index');
+
+describe('GET /api/items/:id/ema', () => {
+  beforeEach(() => {
+    bazaarData.TEST = {
+      history: [
+        { time: 1, buyPrice: 10 },
+        { time: 2, buyPrice: 20 },
+        { time: 3, buyPrice: 30 },
+        { time: 4, buyPrice: 40 },
+      ],
+    };
+  });
+
+  afterEach(() => {
+    delete bazaarData.TEST;
+  });
+
+  test('returns EMA series for given period', async () => {
+    const res = await request(app).get('/api/items/TEST/ema?period=2');
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(3);
+    expect(res.body[0]).toBeCloseTo(15);
+    expect(res.body[1]).toBeCloseTo(25);
+    expect(res.body[2]).toBeCloseTo(35);
+  });
+});

--- a/server/__tests__/preprocess.test.js
+++ b/server/__tests__/preprocess.test.js
@@ -1,4 +1,4 @@
-const { normalize, volatility } = require('../utils/preprocess');
+const { normalize, volatility, ema } = require('../utils/preprocess');
 
 describe('normalize', () => {
   test('scales prices between 0 and 1', () => {
@@ -28,5 +28,16 @@ describe('volatility', () => {
 
   test('returns empty array for insufficient data', () => {
     expect(volatility([{ buyPrice: 10 }])).toEqual([]);
+  });
+});
+
+describe('ema', () => {
+  test('computes exponential moving average', () => {
+    const series = [10, 20, 30, 40];
+    expect(ema(series, 2)).toEqual([15, 25, 35]);
+  });
+
+  test('returns empty array for invalid input', () => {
+    expect(ema([10], 2)).toEqual([]);
   });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const cors = require('cors');
-const { normalize, volatility } = require('./utils/preprocess');
+const { normalize, volatility, ema } = require('./utils/preprocess');
 const { predictNext, predictVolatility } = require('./utils/neural');
 
 const DATA_DIR = path.join(__dirname, 'data');
@@ -137,6 +137,14 @@ app.get('/api/items/:itemId', (req, res) => {
 app.get('/api/items/:itemId/full', (req, res) => {
   const itemId = req.params.itemId.toUpperCase();
   res.json(bazaarData[itemId]?.product || {});
+});
+
+app.get('/api/items/:itemId/ema', (req, res) => {
+  const itemId = req.params.itemId.toUpperCase();
+  const period = parseInt(req.query.period, 10);
+  const history = bazaarData[itemId]?.history || [];
+  const series = history.map((h) => h.buyPrice);
+  res.json(ema(series, period));
 });
 
 app.get('/api/items/:itemId/prediction', (req, res) => {

--- a/server/utils/preprocess.js
+++ b/server/utils/preprocess.js
@@ -20,4 +20,26 @@ function volatility(history) {
   return changes.map((c) => (c - min) / range);
 }
 
-module.exports = { normalize, volatility };
+function ema(series, period) {
+  if (
+    !Array.isArray(series) ||
+    !Number.isFinite(period) ||
+    period <= 0 ||
+    series.length < period
+  )
+    return [];
+  const k = 2 / (period + 1);
+  let sum = 0;
+  for (let i = 0; i < period; i++) {
+    sum += series[i];
+  }
+  let prev = sum / period;
+  const result = [prev];
+  for (let i = period; i < series.length; i++) {
+    prev = series[i] * k + prev * (1 - k);
+    result.push(prev);
+  }
+  return result;
+}
+
+module.exports = { normalize, volatility, ema };


### PR DESCRIPTION
## Summary
- add exponential moving average helper
- expose `/api/items/:itemId/ema` endpoint for price histories
- cover EMA logic and endpoint with tests

## Testing
- `npm run test:server`
- `npm run test:client`


------
https://chatgpt.com/codex/tasks/task_e_68918d35652c832d8fffe8a1b8e12c66