### PR TITLE
refactor: use react query for data fetching

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,7 +6,14 @@ import { router } from './routes';
 import './index.css';
 import { ThemeProvider } from './store/theme';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60, // 1 minute
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -7,11 +7,12 @@ interface Variation {
 }
 
 export default function Analytics() {
-  const { data, isLoading, error } = useQuery<Variation[]>([
-    'variations',
-  ], async () => {
-    const res = await axios.get('/variations?timeframe=1h');
-    return res.data;
+  const { data, isLoading, error } = useQuery<Variation[]>({
+    queryKey: ['variations'],
+    queryFn: async () => {
+      const res = await axios.get('/variations?timeframe=1h');
+      return res.data;
+    },
   });
 
   if (isLoading) return <div>Loading...</div>;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -7,9 +7,12 @@ interface Item {
 }
 
 export default function Dashboard() {
-  const { data } = useQuery<Item[]>(['items'], async () => {
-    const res = await axios.get('/items');
-    return res.data;
+  const { data } = useQuery<Item[]>({
+    queryKey: ['items'],
+    queryFn: async () => {
+      const res = await axios.get('/items');
+      return res.data;
+    },
   });
 
   return (

--- a/frontend/src/pages/Item.tsx
+++ b/frontend/src/pages/Item.tsx
@@ -4,14 +4,20 @@ import axios from 'axios';
 
 export default function Item() {
   const { id } = useParams();
-  const { data, isLoading, error } = useQuery(
-    ['item', id],
-    async () => {
+  const { data, isLoading, error } = useQuery<
+    { time: number; buyPrice: number; sellPrice: number }[]
+  >({
+    queryKey: ['item', id],
+    queryFn: async () => {
       const res = await axios.get(`/items/${id}`);
-      return res.data as { time: number; buyPrice: number; sellPrice: number }[];
+      return res.data as {
+        time: number;
+        buyPrice: number;
+        sellPrice: number;
+      }[];
     },
-    { enabled: !!id }
-  );
+    enabled: !!id,
+  });
 
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error loading item.</div>;


### PR DESCRIPTION
## Summary
- configure global QueryClient with caching defaults
- load dashboard and item data via react-query's `useQuery`
- fetch analytics variations with `useQuery`

## Testing
- `npm run lint --prefix frontend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68918d39d4e0832d984a53242f8502ec