### PR TITLE
Add interval predictions and visualize neural forecast bands

### DIFF
--- a/frontend/src/pages/NeuralPrediction.tsx
+++ b/frontend/src/pages/NeuralPrediction.tsx
@@ -1,0 +1,93 @@
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { Line } from 'react-chartjs-2';
+import 'chart.js/auto';
+
+interface HistoryPoint {
+  time: number;
+  buyPrice: number;
+}
+
+interface PredictionInfo {
+  predictedPrice: number;
+  interval: { low: number; high: number };
+}
+
+export default function NeuralPrediction() {
+  const { id } = useParams<{ id: string }>();
+
+  const { data: history, isLoading: hLoading } = useQuery<HistoryPoint[]>(
+    ['history', id],
+    async () => {
+      const res = await axios.get(`/items/${id}`);
+      return res.data;
+    },
+    { enabled: !!id }
+  );
+
+  const { data: prediction, isLoading: pLoading } = useQuery<PredictionInfo>(
+    ['prediction', id],
+    async () => {
+      const res = await axios.get(`/items/${id}/neural-prediction`);
+      return res.data;
+    },
+    { enabled: !!id }
+  );
+
+  if (!id) return <div>No item selected</div>;
+  if (hLoading || pLoading) return <div>Loading...</div>;
+  if (!history || history.length === 0) return <div>No data for {id}</div>;
+  if (!prediction || prediction.predictedPrice == null)
+    return <div>No prediction available</div>;
+
+  const labels = history.map((h) => new Date(h.time).toLocaleTimeString());
+  labels.push('Prediction');
+
+  const baseNulls = Array(Math.max(history.length - 1, 0)).fill(null);
+  const last = history[history.length - 1].buyPrice;
+  const predicted = [...baseNulls, last, prediction.predictedPrice];
+  const upper = [...baseNulls, last, prediction.interval.high];
+  const lower = [...baseNulls, last, prediction.interval.low];
+
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: 'Buy Price',
+        data: history.map((h) => h.buyPrice),
+        borderColor: 'rgb(75,192,192)',
+        fill: false,
+      },
+      {
+        label: 'Upper Interval',
+        data: upper,
+        borderColor: 'rgba(75,192,192,0)',
+        backgroundColor: 'rgba(75,192,192,0.2)',
+        pointRadius: 0,
+        fill: false,
+      },
+      {
+        label: 'Lower Interval',
+        data: lower,
+        borderColor: 'rgba(75,192,192,0)',
+        backgroundColor: 'rgba(75,192,192,0.2)',
+        pointRadius: 0,
+        fill: '-1',
+      },
+      {
+        label: 'Prediction',
+        data: predicted,
+        borderColor: 'rgb(75,192,192)',
+        fill: false,
+      },
+    ],
+  };
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-2">{id}</h1>
+      <Line data={chartData} />
+    </div>
+  );
+}

--- a/server/__tests__/neural.test.js
+++ b/server/__tests__/neural.test.js
@@ -19,11 +19,13 @@ describe('neural model utilities', () => {
 
   test('trains model and makes prediction', async () => {
     const data = [0.1, 0.2, 0.3, 0.4];
-    const pred = await trainModel('TEST', data);
+    const { prediction: pred, interval } = await trainModel('TEST', data);
     expect(typeof pred).toBe('number');
+    expect(typeof interval).toBe('number');
     expect(fs.existsSync(modelFile)).toBe(true);
     const info = await predictNext('TEST', data);
     expect(typeof info.prediction).toBe('number');
+    expect(typeof info.interval).toBe('number');
     expect(info.modelExists).toBe(true);
     expect(info.trained).toBe(false);
   });
@@ -54,11 +56,13 @@ describe('volatility model utilities', () => {
 
   test('trains model and makes volatility prediction', async () => {
     const data = [0.1, 0.2, 0.1, 0.3];
-    const pred = await trainVolatilityModel('TEST', data);
+    const { prediction: pred, interval } = await trainVolatilityModel('TEST', data);
     expect(typeof pred).toBe('number');
+    expect(typeof interval).toBe('number');
     expect(fs.existsSync(modelFile)).toBe(true);
     const info = await predictVolatility('TEST', data);
     expect(typeof info.prediction).toBe('number');
+    expect(typeof info.interval).toBe('number');
     expect(info.modelExists).toBe(true);
     expect(info.trained).toBe(false);
   });

--- a/server/__tests__/route.test.js
+++ b/server/__tests__/route.test.js
@@ -28,6 +28,9 @@ describe('GET /api/items/:id/neural-prediction', () => {
     expect(res.status).toBe(200);
     expect(res.body.predictedPrice).toBeGreaterThan(30);
     expect(res.body.predictedPrice).toBeLessThanOrEqual(40);
+    expect(res.body.interval.low).toBeLessThanOrEqual(res.body.interval.high);
+    expect(res.body.interval.low).toBeLessThanOrEqual(res.body.predictedPrice);
+    expect(res.body.interval.high).toBeGreaterThanOrEqual(res.body.predictedPrice);
     expect(res.body.modelExists).toBe(false);
     expect(res.body.trained).toBe(true);
     expect(res.body.dataPoints).toBe(4);

--- a/server/index.js
+++ b/server/index.js
@@ -152,7 +152,7 @@ app.get('/api/items/:itemId/neural-prediction', async (req, res) => {
   if (normalized.length < 3) {
     return res.json({});
   }
-  const { prediction, modelExists, trained, dataPoints } = await predictNext(
+  const { prediction, interval, modelExists, trained, dataPoints } = await predictNext(
     itemId,
     normalized
   );
@@ -163,9 +163,14 @@ app.get('/api/items/:itemId/neural-prediction', async (req, res) => {
   const max = Math.max(...prices);
   const min = Math.min(...prices);
   const predictedPrice = prediction * (max - min) + min;
+  const delta = interval * (max - min);
   res.json({
     predictedPrice,
     normalizedPrediction: prediction,
+    interval: {
+      low: predictedPrice - delta,
+      high: predictedPrice + delta,
+    },
     modelExists,
     trained,
     dataPoints,


### PR DESCRIPTION
## Summary
- extend neural prediction utilities to compute a standard-deviation interval and expose it via the API
- draw upper/lower interval bands in the NeuralPrediction page for shaded forecast regions
- cover interval responses in server tests

## Testing
- `npm run test:server`
- `npm test --prefix client`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68918d3d4994832d90db7d3e1a73358b