### PR TITLE
feat: cache items endpoint with Redis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tensorflow/tfjs": "^4.20.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "ioredis": "^5.7.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -527,6 +528,12 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
+      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
       "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1686,6 +1693,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1914,6 +1930,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -2647,6 +2672,30 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ioredis": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
+      "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.3.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -3509,6 +3558,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -4109,6 +4170,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -4437,6 +4519,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-    "type": "commonjs",
-      "dependencies": {
-      "cors": "^2.8.5",
-      "express": "^5.1.0",
-      "@tensorflow/tfjs": "^4.20.0",
-      "zod": "^3.23.8"
-    },
+  "type": "commonjs",
+  "dependencies": {
+    "@tensorflow/tfjs": "^4.20.0",
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
+    "ioredis": "^5.7.0",
+    "zod": "^3.23.8"
+  },
   "devDependencies": {
     "jest": "^29.7.0",
     "supertest": "^7.1.1"

--- a/server/__tests__/cache.test.js
+++ b/server/__tests__/cache.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const { app, bazaarData, fetchBazaar } = require('../index');
+
+describe('Caching behavior for /api/items', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    const now = Date.now();
+    bazaarData.FOO = {
+      history: [{ time: now, buyPrice: 10 }],
+      product: { quick_status: { buyPrice: 10, sellPrice: 12 } },
+    };
+  });
+
+  afterEach(() => {
+    delete bazaarData.FOO;
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('serves cached data and invalidates after fetchBazaar', async () => {
+    let res = await request(app).get('/api/items');
+    expect(res.body[0].quick_status.buyPrice).toBe(10);
+
+    bazaarData.FOO.product.quick_status.buyPrice = 20;
+
+    res = await request(app).get('/api/items');
+    expect(res.body[0].quick_status.buyPrice).toBe(10);
+
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          products: {
+            FOO: { quick_status: { buyPrice: 30, sellPrice: 12 } },
+          },
+        }),
+    });
+
+    await fetchBazaar();
+
+    res = await request(app).get('/api/items');
+    expect(res.body[0].quick_status.buyPrice).toBe(30);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Redis client and helper cache functions
- cache `/api/items` reads and invalidate cache after fetching Bazaar data
- cover caching behavior with tests

## Testing
- `npm run test:server`
- `npm run test:client`


------
https://chatgpt.com/codex/tasks/task_e_68919320ef20832dadf94bf340829f75